### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/src/responsehandlers/FileResponse.dart
+++ b/lib/src/responsehandlers/FileResponse.dart
@@ -18,7 +18,11 @@ class FileResponse extends ResponseHandler {
       request.response.headers.add(HttpHeaders.contentTypeHeader, mimeType);
 
       StreamConsumer<List<int>> streamConsumer = request.response;
-      file.openRead().pipe(streamConsumer).then((streamConsumer) {
+      file
+          .openRead()
+          .cast<List<int>>()
+          .pipe(streamConsumer)
+          .then((streamConsumer) {
         streamConsumer.close();
       });
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: route_provider
 description: >
   Provides backend routing for http-servers. Split routes into separates parts: authentification, controller for data processing and response for outputting the results.
-version: 3.1.6
+version: 3.1.6+1
 author: Robert Beyer <4sternrb@googlemail.com>
 homepage: http://github.com/4stern/dart-routeprovider
 dependencies:


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900