### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+- Prepare for upcoming change to `HttpRequest` and `HttpClientResponse`
+
 ## 4.0.0 (2019-07-01)
 - add tests
 - rename classes

--- a/lib/src/Controller.dart
+++ b/lib/src/Controller.dart
@@ -49,7 +49,7 @@ abstract class Controller {
   Future<String> _getData(HttpRequest request) async {
     Completer<String> _completer = new Completer();
     String bodyData = "";
-    request.transform(utf8.decoder).listen((stream) {
+    utf8.decoder.bind(request).listen((stream) {
       bodyData += stream;
     }, onDone: () {
       _completer.complete(bodyData);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: route_provider
 description: >
   Provides backend routing for http-servers. Split routes into separates parts: authentification, controller for data processing and response for outputting the results.
-version: 4.0.0
+version: 4.0.1
 author: Robert Beyer <4sternrb@googlemail.com>
 homepage: https://github.com/4stern/dart-routeprovider
 dependencies:


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900